### PR TITLE
support for kmod-tpe 2.0.3 & various tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ Default role variables can be found in 'defaults/main.yml'; supported variables 
 # check extended attributes for a soften flag
 # e.g setfattr -n security.tpe -v "soften_exec" /usr/bin/ansible
 
+# kmod_tpe_extras_ignore_softmode: True|False
+# ignores softmode=true to allow extras_* to operate in TPE softmode
+
 # kmod_tpe_extras_proc_kallsyms: True|False
 # denies non-root users from viewing /proc/kallsyms
 
@@ -107,6 +110,7 @@ Default role variables can be found in 'defaults/main.yml'; supported variables 
     - hosts: servers
       roles:
         - role: nexcess.kmod.tpe
+	  kmod_tpe_extras_ignore_softmode: True
           kmod_tpe_extras_proc_kallsyms: True
           kmod_tpe_extras_ps: True
           kmod_tpe_extras_lsmod: True

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ MIT
 
 ## Acknowledgements
 
- - Corey Henderson - https://github.com/cormander/
+ - Corey Henderson - https://github.com/cormander/tpe-lkm/
 
 Creator and maintainer of kmod-tpe port from grsecurity
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,12 +1,8 @@
 ---
-# A behavior change to softmode in version 2.x requires
-# that we invert trusts (whitelist to blacklist) so that
-# we can benefit from 'extras' features without having to
-# adhere to TPE in of itself.
-# If for a higher security system, you want to legitmately
-# enforce TPE, set 'kmod_tpe_trusted_invert' False.
-kmod_tpe_trusted_invert: True
-kmod_tpe_softmode: False
+
+kmod_tpe_softmode: True
+kmod_tpe_extras_ignore_softmode: True
+kmod_tpe_extras_log: True
 
 kmod_tpe_lock: False
 kmod_tpe_log_floodburst: 5
@@ -22,6 +18,8 @@ kmod_tpe_strict: False
 kmod_tpe_dmz_gid: '0'
 kmod_tpe_admin_gid: '0'
 kmod_tpe_trusted_gid: '0'
+kmod_tpe_trusted_invert: False
+kmod_tpe_trusted_apps: []
 kmod_tpe_xattr_soften: True
 kmod_tpe_extras_proc_kallsyms: True
 kmod_tpe_extras_ps: True
@@ -31,3 +29,5 @@ kmod_tpe_extras_harden_ptrace: True
 kmod_tpe_extras_harden_symlink: False
 kmod_tpe_extras_harden_hardlinks: False
 kmod_tpe_extras_restrict_setuid: False
+kmod_tpe_kernel_dmesg_restrict: True
+kmod_tpe_kernel_modules_disabled: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,30 +1,29 @@
 ---
-- name: Install kmod-tpe
-  yum: name=kmod-tpe
-       enablerepo=elrepo,elrepo-testing
-       state=present
+- name: "Install kmod-tpe"
+  yum:
+    name: kmod-tpe
+    enablerepo: elrepo,elrepo-testing
+    state: latest
   register: kmod_tpe_yum
   tags:
     - security
-    - system
-    - tpe
     - kmod-tpe
 
 - block:
-    - name: Load tpe kernel module
-      modprobe: name=tpe
-                state=present
-    - name: Configure tpe.conf
-      template: src=etc/sysctl.d/tpe.conf.j2
-                dest=/etc/sysctl.d/tpe.conf
-                owner=root
-                group=root
-                mode=0644
+    - name: "Load tpe kernel module"
+      modprobe:
+        name: tpe
+        state: present
+    - name: "Configure tpe.conf"
+      template:
+        src: 'etc/sysctl.d/tpe.conf.j2'
+        dest: '/etc/sysctl.d/tpe.conf'
+        owner: root
+        group: root
+        mode: 0640
       notify: reload sysctl
       tags: tpe-sysctl
   when: kmod_tpe_yum|success
   tags:
     - security
-    - system
-    - tpe
     - kmod-tpe

--- a/templates/etc/sysctl.d/tpe.conf.j2
+++ b/templates/etc/sysctl.d/tpe.conf.j2
@@ -1,195 +1,32 @@
 # {{ ansible_managed }}
 
-{% if kmod_tpe_extras_harden_ptrace is defined %}
-{%   if kmod_tpe_extras_harden_ptrace %}
-tpe.extras.harden_ptrace = 1
-{%   else %}
-tpe.extras.harden_ptrace = 0
-{%   endif %}
-{% else %}
-tpe.extras.harden_ptrace = 0
-{% endif %}
-{% if kmod_tpe_extras_proc_kallsyms is defined %}
-{%   if kmod_tpe_extras_proc_kallsyms %}
-tpe.extras.proc_kallsyms = 1
-{%   else %}
-tpe.extras.proc_kallsyms = 0
-{%   endif %}
-{% else %}
-#tpe.extras.proc_kallsyms = 0
-{% endif %}
-{% if kmod_tpe_extras_ps_gid is defined %}
-tpe.extras.ps_gid = {{ kmod_tpe_extras_ps_gid }}
-{% else %}
-#tpe.extras.ps_gid = 0
-{% endif %}
-{% if kmod_tpe_extras_ps is defined %}
-{%   if kmod_tpe_extras_ps %}
-tpe.extras.ps = 1
-{%   else %}
-tpe.extras.ps = 0
-{%   endif %}
-{% else %}
-#tpe.extras.ps = 0
-{% endif %}
-{% if kmod_tpe_extras_lsmod is defined %}
-{%   if kmod_tpe_extras_lsmod %}
-tpe.extras.lsmod = 1
-{%   else %}
-tpe.extras.lsmod = 0
-{%   endif %}
-{% else %}
-#tpe.extras.lsmod = 0
-{% endif %}
-{% if kmod_tpe_extras_harden_symlink is defined %}
-{%   if kmod_tpe_extras_harden_symlink %}
-tpe.extras.harden_symlink = 1
-{%   else %}
-tpe.extras.harden_symlink = 0
-{%   endif %}
-{% else %}
-#tpe.extras.harden_symlink = 0
-{% endif %}
-{% if kmod_tpe_extras_harden_hardlinks is defined %}
-{%   if kmod_tpe_extras_harden_hardlinks %}
-tpe.extras.harden_hardlinks = 1
-{%   else %}
-tpe.extras.harden_hardlinks = 0
-{%   endif %}
-{% else %}
-#tpe.extras.harden_hardlinks = 0
-{% endif %}
-{% if kmod_tpe_extras_restrict_setuid is defined %}
-{%   if kmod_tpe_extras_restrict_setuid %}
-tpe.extras.restrict_setuid = 1
-{%   else %}
-tpe.extras.restrict_setuid = 0
-{%   endif %}
-{% else %}
-#tpe.extras.restrict_setuid = 0
-{% endif %}
-{% if kmod_tpe_lock is defined %}
-{%   if kmod_tpe_lock %}
-tpe.lock = 1
-{%   else %}
-tpe.lock = 0
-{%   endif %}
-{% else %}
-#tpe.lock = 0
-{% endif %}
-{% if kmod_tpe_log_floodburst is defined %}
 tpe.log_floodburst = {{ kmod_tpe_log_floodburst }}
-{% else %}
-#tpe.log_floodburst = 5
-{% endif %}
-{% if kmod_tpe_log_floodtime is defined %}
 tpe.log_floodtime = {{ kmod_tpe_log_floodtime }}
-{% else %}
-#tpe.log_floodtime = 5
-{% endif %}
-{% if kmod_tpe_log_max is defined %}
 tpe.log_max = {{ kmod_tpe_log_max }}
-{% else %}
-#tpe.log_max = 50
-{% endif %}
-{% if kmod_tpe_log is defined %}
-{%   if kmod_tpe_log %}
-tpe.log = 1
-{%   else %}
-tpe.log = 0
-{%   endif %}
-{% else %}
-#tpe.log = 1
-{% endif %}
-{% if kmod_tpe_log_verbose is defined %}
-{%   if kmod_tpe_log_verbose %}
-tpe.log_verbose = 1
-{%   else %}
-tpe.log_verbose = 0
-{%   endif %}
-{% else %}
-#tpe.log_verbose = 1
-{% endif %}
-{% if kmod_tpe_kill is defined %}
-{%   if kmod_tpe_kill %}
-tpe.kill = 1
-{%   else %}
-tpe.kill = 0
-{%   endif %}
-{% else %}
-#tpe.kill = 0
-{% endif %}
-{% if kmod_tpe_hardcoded_path is defined %}
-tpe.hardcoded_path = {{ kmod_tpe_hardcoded_path|join(';') }}
-{% else %}
-#tpe.hardcoded_path =
-{% endif %}
-{% if kmod_tpe_paranoid is defined %}
-{%   if kmod_tpe_paranoid %}
-tpe.paranoid = 1
-{%   else %}
-tpe.paranoid = 0
-{%   endif %}
-{% else %}
-#tpe.paranoid = 0
-{% endif %}
-{% if kmod_tpe_check_file is defined %}
-{%   if kmod_tpe_check_file %}
-tpe.check_file = 1
-{%   else %}
-tpe.check_file = 0
-{%   endif %}
-{% else %}
-#tpe.check_file = 1
-{% endif %}
-{% if kmod_tpe_strict is defined %}
-{%   if kmod_tpe_strict %}
-tpe.strict = 1
-{%   else %}
-tpe.strict = 0
-{%   endif %}
-{% else %}
-#tpe.strict = 1
-{% endif %}
-{% if kmod_tpe_dmz_gid is defined %}
+tpe.log = {{ '0' if kmod_tpe_log is defined and not kmod_tpe_log else '1' }}
+tpe.log_verbose = {{ '0' if kmod_tpe_log_verbose is defined and not kmod_tpe_log_verbose else '1' }}
+tpe.kill = {{ '1' if kmod_tpe_kill is defined and kmod_tpe_kill else '0' }}
+tpe.hardcoded_path = {{ kmod_tpe_hardcoded_path|join(':') }}
+tpe.trusted_apps = {{ kmod_tpe_trusted_apps|join(',') }}
+tpe.paranoid = {{ '1' if kmod_tpe_paranoid is defined and kmod_tpe_paranoid else '0' }}
+tpe.check_file = {{ '0' if kmod_tpe_check_file is defined and not kmod_tpe_check_file else '1' }}
+tpe.strict = {{ '0' if kmod_tpe_strict is defined and not kmod_tpe_strict else '1' }}
 tpe.dmz_gid = {{ kmod_tpe_dmz_gid }}
-{% else %}
-#tpe.dmz_gid = 0
-{% endif %}
-{% if kmod_tpe_admin_gid is defined %}
-tpe.admin_gid = {{ kmod_tpe_admin_gid }}
-{% else %}
-#tpe.admin_gid = 0
-{% endif %}
-{% if kmod_tpe_trusted_gid is defined %}
-tpe.trusted_gid = {{ kmod_tpe_trusted_gid }}
-{% else %}
-#tpe.trusted_gid = 0
-{% endif %}
-{% if kmod_tpe_trusted_invert is defined %}
-{%   if kmod_tpe_trusted_invert %}
-tpe.trusted_invert = 1
-{%   else %}
-tpe.trusted_invert = 0
-{%   endif %}
-{% else %}
-#tpe.trusted_invert = 0
-{% endif %}
-{% if kmod_tpe_softmode is defined %}
-{%   if kmod_tpe_softmode %}
-tpe.softmode = 1
-{%   else %}
-tpe.softmode = 0
-{%   endif %}
-{% else %}
-tpe.softmode = 0
-{% endif %}
-{% if kmod_tpe_xattr_soften is defined %}
-{%   if kmod_tpe_xattr_soften %}
-tpe.xattr_soften = 1
-{%   else %}
-tpe.xattr_soften = 0
-{%   endif %}
-{% else %}
-#tpe.xattr_soften = 1
-{% endif %}
+tpe.admin_gid = {{kmod_tpe_admin_gid }}
+tpe.trusted_gid = {{ kmod_tpe_trusted_gid }} 
+tpe.trusted_invert = {{ '1' if kmod_tpe_trusted_invert is defined and kmod_tpe_trusted_invert else '0' }}
+tpe.xattr_soften = {{ '0' if kmod_tpe_xattr_soften is defined and not kmod_tpe_xattr_soften else '1' }}
+tpe.softmode = {{ '1' if kmod_tpe_softmode is defined and kmod_tpe_softmode else '0' }}
+tpe.lock = {{ '1' if kmod_tpe_lock is defined and kmod_tpe_lock else '0' }}
+tpe.extras.ignore_softmode = {{ '1' if kmod_tpe_extras_ignore_softmode is defined and kmod_tpe_extras_ignore_softmode else '0' }}
+tpe.extras.log = {{ '0' if kmod_tpe_extras_log is defined and not kmod_tpe_extras_log else '1' }}
+tpe.extras.ps = {{ '1' if kmod_tpe_extras_ps is defined and kmod_tpe_extras_ps else '0' }}
+tpe.extras.ps_gid = {{ kmod_tpe_extras_ps_gid }}
+tpe.extras.restrict_setuid = {{ '1' if kmod_tpe_extras_restrict_setuid is defined and kmod_tpe_extras_restrict_setuid else '0' }}
+tpe.extras.lsmod = {{ '0' if kmod_tpe_extras_lsmod is defined and not kmod_tpe_extras_lsmod else '1' }}
+tpe.extras.proc_kallsyms = {{ '0' if kmod_tpe_extras_proc_kallsyms is defined and not kmod_tpe_extras_proc_kallsyms else '1' }}
+tpe.extras.harden_ptrace = {{ '0' if kmod_tpe_extras_harden_ptrace is defined and not kmod_tpe_extras_harden_ptrace else '1' }}
+tpe.extras.hide_uname = {{ '1' if kmod_tpe_extras_hide_uname is defined and kmod_tpe_extras_hide_uname else '0' }}
+
+kernel.modules_disabled = {{ '1' if kmod_tpe_kernel_modules_disabled is defined and kmod_tpe_kernel_modules_disabled else '0' }}
+kernel.dmesg_restrict = {{ '1' if kmod_tpe_kernel_dmesg_restrict is defined and kmod_tpe_kernel_dmesg_restrict else '0' }}


### PR DESCRIPTION
[Change] added support for kmod-tpe 2.0.3
[Change] reworked format of tpe.conf template
[Change] removed invert trust behavior fix re cormander/tpe-lkm#19
[New] added tpe.extras.ignore_softmode and tpe.extras_log
[New] added abstraction of kernel dmesg restrictions, default enabled
[Change] updated README.md for new variable definitions
[Change] refactored tasks/main.yml for consistency